### PR TITLE
fix Can't use function return value in write context

### DIFF
--- a/histou/basic.php
+++ b/histou/basic.php
@@ -165,8 +165,9 @@ class Basic
             Basic::getConfigKey($config, 'general', 'socketTimeout'),
             10
         );
-        if (!empty(Basic::getConfigKey($config, 'general', 'phpCommand'))) {
-            static::$phpCommand = Basic::getConfigKey($config, 'general', 'phpCommand');
+        $phpCommand = Basic::getConfigKey($config, 'general', 'phpCommand');
+        if (!empty($phpCommand)) {
+            static::$phpCommand = $phpCommand;
         }
         Basic::setConstant(
             "TMP_FOLDER",


### PR DESCRIPTION
This fixes the "PHP Fatal error:  Can't use function return value in write context" error.
Using a return value in empty() does't work.