### PR TITLE
fix typo in disablePanelTitle parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## v0.4.0 - 30.11.2016
 ### Features
-- URL/Config param to disable paneltitles for bigger graphs. Url flag: disablePanelTitel - works now also on simple templates.
+- URL/Config param to disable paneltitles for bigger graphs. Url flag: disablePanelTitle - works now also on simple templates.
 - URL param to specify a certain template. Take a look at the [README](https://github.com/Griesbacher/histou#url-parameters).
 - URL param to disable Influxdb lookup. Take a look at the [README](https://github.com/Griesbacher/histou#url-parameters).
 
@@ -21,7 +21,7 @@
 
 ## v0.3.10 - 23.11.2016
 ### Features
-- URL/Config param to disable paneltitles for bigger graphs. Url flag: disablePanelTitel
+- URL/Config param to disable paneltitles for bigger graphs. Url flag: disablePanelTitle
 
 ## v0.3.9 - 09.11.2016
 ### Features

--- a/histou/basic.php
+++ b/histou/basic.php
@@ -97,8 +97,8 @@ class Basic
             }
         }
 
-        if (isset($_GET['disablePanelTitel'])) {
-            static::$disablePanelTitel = true;
+        if (isset($_GET['disablePanelTitle'])) {
+            static::$disablePanelTitle = true;
         }
 
         if (isset($_GET['debug'])) {


### PR DESCRIPTION
Right now, it was not possible to use this parameter  because of a typo in disablePanelTitel.
This patches changes all disablePanelTitel into disablePanelTitle