### PR TITLE
fix legend parameter

### DIFF
--- a/histou/grafana/graphpanel/graphpanelinfluxdb.php
+++ b/histou/grafana/graphpanel/graphpanelinfluxdb.php
@@ -29,7 +29,7 @@ class GraphPanelInfluxdb extends GraphPanel
     **/
     public function __construct($title, $legendShow = SHOW_LEGEND, $id = -1)
     {
-        parent::__construct($title, 'graph', $id);
+        parent::__construct($title, $legendShow, $id);
     }
 
     public function createTarget(array $filterTags = array(), $datasource = INFLUXDB_DB)


### PR DESCRIPTION
the second argument to GraphPanel it $legendShow, not type. Right now
legend was always set to 'graph' which is true and always displays
the legend, regardless of the url parameter.