### PR TITLE
Additional default config for influxdb queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Here are some of the important config-options:
 |general|databaseType|Choose between influxDB and elasticsearch. Elasticsearch farewide not that supported as InfluxDB is, because InfluxDB is the main target database.|
 |general|disablePanelTitle|If this is set to true the PanelTitels are hidden globaly, there is an URL Flag which does it just with the current page. It is usefull to get a bigger Graphpicture.|
 |graph|defaultInfluxdbGroupByTime|Value: `time_interval[,offset_interval]`. This option will set the [GROUP BY time intervals](https://docs.influxdata.com/influxdb/latest/query_language/data_exploration/#group-by-time-intervals) value for all influxdb queries. The `time_interval` and the `offset_interval` are [duration literal](https://docs.influxdata.com/influxdb/v1.4/query_language/spec/#durations), E.g.: `5m`, `1h`, `5m,1m`. Each template can overwrite this option.
+|graph|defaultInfluxdbGroupByTimeFill|Value: `fill_option`. This will set the fill condition for all influxdb queries. Possible value are listed and explained here: [GROUP BY time intervals and fill()](https://docs.influxdata.com/influxdb/v1.4/query_language/data_exploration/#group-by-time-intervals-and-fill)
 |folder|defaultTemplateFolder|This is the path to the folder containing the default templates|
 |folder|customTemplateFolder|This is the path to the folder containing the custom templates. The templates in this folder will override files in the default folder, if they have the same filename|
 |influxdb|url|You can guess it...|

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here are some of the important config-options:
 |general|specialChar|Can be used to create more specific regex within the rules. E.g. $host = '&host&' will be replaced with 'linux-server1' if the select hostname is linux-server1. This works likewise with host, service, command.|
 |general|databaseType|Choose between influxDB and elasticsearch. Elasticsearch farewide not that supported as InfluxDB is, because InfluxDB is the main target database.|
 |general|disablePanelTitle|If this is set to true the PanelTitels are hidden globaly, there is an URL Flag which does it just with the current page. It is usefull to get a bigger Graphpicture.|
+|graph|defaultInfluxdbGroupByTime|Value: `time_interval[,offset_interval]`. This option will set the [GROUP BY time intervals](https://docs.influxdata.com/influxdb/latest/query_language/data_exploration/#group-by-time-intervals) value for all influxdb queries. The `time_interval` and the `offset_interval` are [duration literal](https://docs.influxdata.com/influxdb/v1.4/query_language/spec/#durations), E.g.: `5m`, `1h`, `5m,1m`. Each template can overwrite this option.
 |folder|defaultTemplateFolder|This is the path to the folder containing the default templates|
 |folder|customTemplateFolder|This is the path to the folder containing the custom templates. The templates in this folder will override files in the default folder, if they have the same filename|
 |influxdb|url|You can guess it...|

--- a/histou.ini.example
+++ b/histou.ini.example
@@ -12,6 +12,7 @@ disablePanelTitle = false
 
 [graph]
 ; defaultInfluxdbGroupByTime = 5m
+; defaultInfluxdbGroupByTimeFill = previous
 
 [folder]
 defaultTemplateFolder = "templates/default/"

--- a/histou.ini.example
+++ b/histou.ini.example
@@ -10,6 +10,9 @@ forecastDatasourceName = "nagflux_forecast"
 ; disable the Panel Titel globally
 disablePanelTitle = false
 
+[graph]
+; defaultInfluxdbGroupByTime = 5m
+
 [folder]
 defaultTemplateFolder = "templates/default/"
 customTemplateFolder = "templates/custom/"

--- a/histou/basic.php
+++ b/histou/basic.php
@@ -33,6 +33,8 @@ class Basic
     public static $disablePanelTitle = false;
     public static $specificTemplate = '';
     public static $disablePerfdataLookup = false;
+
+    public static $defaultInfluxdbGroupByTime = null;
  
     /**
     Parses the GET parameter.
@@ -215,6 +217,11 @@ class Basic
             strtolower(Basic::getConfigKey($config, 'general', 'forecastDatasourceName')),
             "nagflux_forecast"
         );
+
+        $defaultInfluxdbGroupByTime = Basic::getConfigKey($config, 'graph', 'defaultInfluxdbGroupByTime');
+        if (!empty($defaultInfluxdbGroupByTime)) {
+            static::$defaultInfluxdbGroupByTime = $defaultInfluxdbGroupByTime;
+        }
 
         Basic::setConstant(
             "URL",

--- a/histou/basic.php
+++ b/histou/basic.php
@@ -35,7 +35,8 @@ class Basic
     public static $disablePerfdataLookup = false;
 
     public static $defaultInfluxdbGroupByTime = null;
- 
+    public static $defaultInfluxdbGroupByTimeFill = null;
+
     /**
     Parses the GET parameter.
     @return null.
@@ -221,6 +222,10 @@ class Basic
         $defaultInfluxdbGroupByTime = Basic::getConfigKey($config, 'graph', 'defaultInfluxdbGroupByTime');
         if (!empty($defaultInfluxdbGroupByTime)) {
             static::$defaultInfluxdbGroupByTime = $defaultInfluxdbGroupByTime;
+        }
+        $defaultInfluxdbGroupByTimeFill = Basic::getConfigKey($config, 'graph', 'defaultInfluxdbGroupByTimeFill');
+        if (!empty($defaultInfluxdbGroupByTimeFill)) {
+            static::$defaultInfluxdbGroupByTimeFill = $defaultInfluxdbGroupByTimeFill;
         }
 
         Basic::setConstant(

--- a/histou/grafana/graphpanel/graphpanelinfluxdb.php
+++ b/histou/grafana/graphpanel/graphpanelinfluxdb.php
@@ -34,7 +34,7 @@ class GraphPanelInfluxdb extends GraphPanel
 
     public function createTarget(array $filterTags = array(), $datasource = INFLUXDB_DB)
     {
-        return array(
+        $target = array(
                     'measurement' => 'metrics',
                     'alias' => '$col',
                     'select' => array(),
@@ -43,6 +43,15 @@ class GraphPanelInfluxdb extends GraphPanel
                     'resultFormat' => 'time_series',
                     'datasource' => $datasource
                     );
+
+        $groupBy = $this->createDefaultGroupBy();
+        if (!empty($groupBy)) {
+            // set the groupBy to the target only if it is not empty to
+            // so that if it is empty grafana will set his own default values
+            $target['groupBy'] = $groupBy;
+        }
+
+        return $target;
     }
     
     /**
@@ -63,6 +72,21 @@ class GraphPanelInfluxdb extends GraphPanel
             $i++;
         }
         return $tags;
+    }
+
+    /**
+    Create and return groupBy array with defalt values.
+    **/
+    private function createDefaultGroupBy()
+    {
+        $groupBy = array();
+
+        if (!is_null(\histou\Basic::$defaultInfluxdbGroupByTime)) {
+            $time = array("params" => array(\histou\Basic::$defaultInfluxdbGroupByTime), "type" => "time");
+            array_push($groupBy, $time);
+        }
+
+        return $groupBy;
     }
 
     /**

--- a/histou/grafana/graphpanel/graphpanelinfluxdb.php
+++ b/histou/grafana/graphpanel/graphpanelinfluxdb.php
@@ -86,6 +86,11 @@ class GraphPanelInfluxdb extends GraphPanel
             array_push($groupBy, $time);
         }
 
+        if(!is_null(\histou\Basic::$defaultInfluxdbGroupByTimeFill)) {
+            $fill = array("params" => array(\histou\Basic::$defaultInfluxdbGroupByTimeFill), "type" => "fill");
+            array_push($groupBy, $fill);
+        }
+
         return $groupBy;
     }
 

--- a/tests/histou/grafana/graphpanel/graphpanelinfluxbtest.php
+++ b/tests/histou/grafana/graphpanel/graphpanelinfluxbtest.php
@@ -715,6 +715,7 @@ class GraphpanelInfluxdbTest extends \MyPHPUnitFrameworkTestCase
                         );
         $this->assertSame($expected, $target);
         $this->assertSame(array("20m" , "30m"), \histou\grafana\dashboard\Dashboard::$forecast);
+
     }
 
     public function testGraphPanelInfluxdbStack()
@@ -749,5 +750,14 @@ class GraphpanelInfluxdbTest extends \MyPHPUnitFrameworkTestCase
                             ),
             $gpanel->toArray()['legend']
         );
+    }
+    public function testGenTargetWithDefaultInfluxdbGroupByTime()
+    {
+        $this->init();
+        \histou\Basic::$defaultInfluxdbGroupByTime = '5m';
+        $panel = \histou\grafana\graphpanel\GraphPanelFactory::generatePanel('panel');
+        $target = $panel->genTargetSimple('host', 'service', 'command', 'time');
+        $expected = array( array("params" => array('5m'), "type" => "time") );
+        $this->assertSame($target['groupBy'], $expected);
     }
 }

--- a/tests/histou/grafana/graphpanel/graphpanelinfluxbtest.php
+++ b/tests/histou/grafana/graphpanel/graphpanelinfluxbtest.php
@@ -760,4 +760,17 @@ class GraphpanelInfluxdbTest extends \MyPHPUnitFrameworkTestCase
         $expected = array( array("params" => array('5m'), "type" => "time") );
         $this->assertSame($target['groupBy'], $expected);
     }
+    public function testGenTargetWithDefaultInfluxdbGroupByTimeFill()
+    {
+        $this->init();
+        \histou\Basic::$defaultInfluxdbGroupByTime = '5m';
+        \histou\Basic::$defaultInfluxdbGroupByTimeFill = 'previous';
+        $panel = \histou\grafana\graphpanel\GraphPanelFactory::generatePanel('panel');
+        $target = $panel->genTargetSimple('host', 'service', 'command', 'time');
+        $expected = array(
+            array("params" => array('5m'), "type" => "time"),
+            array("params" => array('previous'), "type" => "fill") ,
+        );
+        $this->assertSame($target['groupBy'], $expected);
+    }
 }


### PR DESCRIPTION
Hi,
We have work on crate two new default options for all influxdb queries. We need this two options because we want to set them for all graph without the need to change all templates, but always allow templates to overwrite them.

The two options are:
* defaultInfluxdbGroupByTime
* defaultInfluxdbGroupByTimeFill

These two options are fully descript in the README.md, and for both options, we have created a unittest.

If these two options are not set, nothing will change from the previous behavior. 

Bye,
Davide