### PR TITLE
urldecode host and service

### DIFF
--- a/histou/basic.php
+++ b/histou/basic.php
@@ -64,7 +64,7 @@ class Basic
         
         if (!static::$request) {
             if (isset($_GET['host']) && !empty($_GET['host'])) {
-                define("HOST", $_GET["host"]);
+                define("HOST", urldecode($_GET["host"]));
             } elseif (isset($args['host']) && !empty($args['host'])) {
                 define("HOST", $args["host"]); // @codeCoverageIgnore
             } else {  // @codeCoverageIgnore
@@ -72,7 +72,7 @@ class Basic
             }
             
             if (isset($_GET['service']) && !empty($_GET['service'])) {
-                define("SERVICE", $_GET["service"]);
+                define("SERVICE", urldecode($_GET["service"]));
             } elseif (isset($args['service']) && !empty($args['service'])) {
                 define("SERVICE", $args["service"]);  // @codeCoverageIgnore
             } else {   // @codeCoverageIgnore


### PR DESCRIPTION
In some scenarios I experienced the query which was sent to Influx, to
include urlencoded strings. As a result data would not be fetched from
the database correctly.

This commit ensures that the constants for HOST and SERVICE are
urldecoded in order to avoid the above.

Signed-off-by: Jacob Hansen <jhansen@op5.com>