### PR TITLE
group results by filling linear

### DIFF
--- a/histou/grafana/graphpanel/graphpanelinfluxdb.php
+++ b/histou/grafana/graphpanel/graphpanelinfluxdb.php
@@ -41,7 +41,9 @@ class GraphPanelInfluxdb extends GraphPanel
                     'tags' => $this->createFilterTags($filterTags),
                     'dsType' => 'influxdb',
                     'resultFormat' => 'time_series',
-                    'datasource' => $datasource
+                    'datasource' => $datasource,
+                    'groupBy' => array(array("params"=>array("\$__interval"), "type"=> "time"),
+                                       array("params"=>array("linear"), "type"=> "fill"))
                     );
     }
     


### PR DESCRIPTION
When importing old data from pnp (`migrate_pnp_to_nagflux.pl`), the lines are inconsistent, see screenshot;

![histou_plot](https://user-images.githubusercontent.com/232433/49552287-28cc0200-f8f3-11e8-9112-3d5572fc47be.png)

I force linear fill to avoid it.