### PR TITLE
fix Uncaught ErrorException: sizeof(): Parameter must be an array or …

### DIFF
--- a/index.php
+++ b/index.php
@@ -64,7 +64,10 @@ if (!\histou\Basic::$disablePerfdataLookup){
 		SERVICE
 	);
 
-	$perfDataSize = sizeof($perfData);
+	$perfDataSize = 0;
+	if(is_array($perfData)) {
+		$perfDataSize = sizeof($perfData);
+	}
 	if ($perfDataSize < 4) {
 		if ($perfDataSize == 1) {
 			\histou\Basic::returnData(\histou\Debug::errorMarkdownDashboard('# Database Error: '.$perfData), 1);


### PR DESCRIPTION
…an object that implements Countable

when using php 7.2 or later, sizeof only accepts arrays. But in case of an empty
result it contains a string "No data found".