### PR TITLE
allow interfaces with underscore

### DIFF
--- a/templates/default/check_nwc_health-interface.php
+++ b/templates/default/check_nwc_health-interface.php
@@ -25,7 +25,7 @@ $genTemplate = function ($perfData) {
         $templateName,
         $perfData['host'],
         $perfData['service'],
-        $regex = '^(.*?)_(\w+?)_\w+$',
+        $regex = '^(.*?)_([a-zA-Z]+?)_[a-zA-Z]+$',
         $multiFormat = true,
         $includeAll = false
     );
@@ -34,7 +34,7 @@ $genTemplate = function ($perfData) {
     $interfaces = array();
     $types = array();
     foreach ($perfData['perfLabel'] as $key => $value) {
-        if (preg_match(';^(.*?)_(\w+?)_\w+$;', $key, $hit)) {
+        if (preg_match(';^(.*?)_([a-zA-Z]+?)_[a-zA-Z]+$;', $key, $hit)) {
             array_push($interfaces, $hit[1]);
             array_push($types, $hit[2]);
         }


### PR DESCRIPTION
Interfaces like wan0_0 (perfLabel = wan0_0_traffic_in) did not correct match the regex ^(.*?)_(\w+?)_\w+$, because the \w works like [a-zA-Z0-9_]. The proposed change does only match letters for the perfLabel type and direction.