### PR TITLE
histou trows an error if victoriametrics runs in ssl mode

### DIFF
--- a/histou/grafana/graphpanel/graphpanel.php
+++ b/histou/grafana/graphpanel/graphpanel.php
@@ -257,6 +257,9 @@ abstract class GraphPanel extends \histou\grafana\Panel
                 return 'Bps'; # bytes/sec(SI)
             case 'binBps':
                 return 'binBps'; # bytes/sec(IEC)
+            case 'bps':
+            case 'binbps':
+                return $unit;
             case '%':
             case 'percent':
             case 'pct':


### PR DESCRIPTION
This patch disables TLS certificate checks to the database

![grafik](https://github.com/user-attachments/assets/334a6ddf-96ec-42b6-ac6a-8c231e0c70eb)
